### PR TITLE
fix: set cursor foreground

### DIFF
--- a/src/catppuccin-frappe.theme
+++ b/src/catppuccin-frappe.theme
@@ -1,6 +1,7 @@
 [Scheme]
 Name=Catppuccin-Frappe
 ColorCursor=#F2D5CF
+ColorCursorForeground=#303446
 ColorCursorUseDefault=FALSE
 ColorForeground=#C6D0F5
 ColorBackground=#303446

--- a/src/catppuccin-latte.theme
+++ b/src/catppuccin-latte.theme
@@ -1,6 +1,7 @@
 [Scheme]
 Name=Catppuccin-Latte
 ColorCursor=#DC8A78
+ColorCursorForeground=#eff1f5
 ColorCursorUseDefault=FALSE
 ColorForeground=#4C4F69
 ColorBackground=#EFF1F5

--- a/src/catppuccin-macchiato.theme
+++ b/src/catppuccin-macchiato.theme
@@ -1,6 +1,7 @@
 [Scheme]
 Name=Catppuccin-Macchiato
 ColorCursor=#F4DBD6
+ColorCursorForeground=#24273a
 ColorCursorUseDefault=FALSE
 ColorForeground=#CAD3F5
 ColorBackground=#24273A

--- a/src/catppuccin-mocha.theme
+++ b/src/catppuccin-mocha.theme
@@ -1,6 +1,7 @@
 [Scheme]
 Name=Catppuccin-Mocha
 ColorCursor=#F5E0DC
+ColorCursorForeground=#1e1e2e
 ColorCursorUseDefault=FALSE
 ColorForeground=#CDD6F4
 ColorBackground=#1E1E2E


### PR DESCRIPTION
Based on [the Alacritty port's cursor](https://github.com/catppuccin/alacritty/blob/main/catppuccin-macchiato.yml#L11) I believe the cursor is meant to have a Base colored foreground. Right now it's unset, which means it's just whatever the foreground color usually is, which is almost always unreadable against the Rosewater cursor.